### PR TITLE
dev - Set BCGov Arches Common app version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "arches==7.6.4",
     #"arches @ git+https://github.com/bcgov/arches.git@stable/7.6.3_bcgov_11578_11679_11689",
 ]
-version = "0.9.0"
+version = "1.0.0"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Bump version number for first PROD release.