### PR TITLE
1253 Move reusable LabelledInput and LabelledCheckboxInput into common

### DIFF
--- a/bcgov_arches_common/src/bcgov_arches_common/components/labelledinput/LabelledCheckbox.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/components/labelledinput/LabelledCheckbox.vue
@@ -2,77 +2,68 @@
 import { computed } from 'vue';
 
 const props = defineProps({
-    label: { type: String, default: '' },
-    hint: { type: String, default: '' },
-    required: { type: Boolean, default: false },
-    inputName: { type: String, default: '' },
-    errorMessage: { type: String, default: '' },
+  label: { type: String, default: '' },
+  hint: { type: String, default: '' },
+  required: { type: Boolean, default: false },
+  inputName: { type: String, default: '' },
+  errorMessage: { type: String, default: '' },
 });
 import Message from 'primevue/message';
 
 const isRequired = computed(() => {
-    return 'form-label' + (props.required ? ' required' : '');
+  return 'form-label' + (props.required ? ' required' : '');
 });
 </script>
 
 <template>
-    <div class="labelled-input flex flex-row gap-2">
-        <div style="display: inline-block"><slot></slot></div>
-        <label
-            style="display: inline-block"
-            :for="props.inputName"
-            :class="isRequired"
-            >{{ props.label }}</label
-        >
-
-        <Message
-            class="label-message"
-            severity="secondary"
-            >{{ props.hint }}</Message
-        >
-        <Message
-            class="label-message"
-            severity="error"
-            >{{ props.errorMessage }}</Message
-        >
+  <div class="flex flex-row gap-2">
+    <div style="display: inline-block">
+      <slot></slot>
     </div>
+    <label style="display: inline-block" :for="props.inputName" :class="isRequired">{{ props.label }}</label>
+  </div>
+  <Message class="label-message" severity="secondary">{{ props.hint }}</Message>
+  <Message class="label-message" severity="error">{{ props.errorMessage }}</Message>
 </template>
 
 <style scoped>
 label.required::before {
-    color: red;
-    content: '*';
-    padding-right: 0.1rem;
+  color: red;
+  content: '*';
+  padding-right: 0.1rem;
+  //margin-left: 0.5rem;
+  //position: absolute;
+  //left: -5px;
 }
 
-.labelled-input > label {
-    display: block;
-    max-width: 100%;
-    margin-bottom: 0;
-    font-weight: 500;
-    font-size: 0.8rem;
-    margin-top: 1rem;
+.labelled-input>label {
+  display: block;
+  max-width: 100%;
+  margin-bottom: 0;
+  font-weight: 500;
+  font-size: 0.8rem;
+  margin-top: 1rem;
 }
 </style>
 
 <style>
-.label-message > .p-message-content {
-    padding: 0 0.5rem;
-    font-size: 0.6rem;
-    background: var(--p-panel-background);
-    border: none;
+.label-message>.p-message-content {
+  padding: 0 0.5rem;
+  font-size: 0.6rem;
+  background: var(--p-panel-background);
+  border: none;
 }
 
 .p-message.label-message {
-    outline-style: none;
-    box-shadow: none;
+  outline-style: none;
+  box-shadow: none;
 }
 
 .label-message .p-message-text {
-    font-size: 0.6rem !important;
+  font-size: 0.6rem !important;
 }
 
 .p-message-secondary {
-    background: unset;
+  background: unset;
 }
 </style>

--- a/bcgov_arches_common/src/bcgov_arches_common/components/labelledinput/LabelledInput.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/components/labelledinput/LabelledInput.vue
@@ -1,79 +1,66 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-
-const props = defineProps({
-    label: { type: String, default: '' },
-    hint: { type: String, default: '' },
-    required: { type: Boolean, default: false },
-    inputName: { type: String, default: '' },
-    errorMessage: { type: String, default: '' },
-});
 import Message from 'primevue/message';
 
+const props = defineProps({
+  label: { type: String, default: '' },
+  hint: { type: String, default: '' },
+  required: { type: Boolean, default: false },
+  inputName: { type: String, default: '' },
+  errorMessage: { type: String, default: '' },
+});
 const isRequired = computed(() => {
-    return 'form-label' + (props.required ? ' required' : '');
+  return 'form-label' + (props.required ? ' required' : '');
 });
 </script>
 
 <template>
-    <div class="labelled-input flex flex-row gap-2">
-        <label
-            :for="props.inputName"
-            :class="isRequired"
-            >{{ props.label }}</label
-        >
-        <slot></slot>
-        <Message
-            class="label-message"
-            severity="secondary"
-            >{{ props.hint }}</Message
-        >
-        <Message
-            class="label-message"
-            severity="error"
-            >{{ props.errorMessage }}</Message
-        >
-    </div>
+  <div class="mb-2">
+    <label :for="props.inputName" :class="isRequired">{{ props.label }}</label>
+    <slot></slot>
+    <Message class="label-message" severity="secondary">{{ props.hint }}</Message>
+    <Message class="label-message" severity="error">{{ props.errorMessage }}</Message>
+  </div>
 </template>
 
 <style scoped>
 label.required::before {
-    color: red;
-    content: '*';
-    padding-right: 0.1rem;
-    //margin-left: 0.5rem;
-    //position: absolute;
-    //left: -5px;
+  color: red;
+  content: '*';
+  padding-right: 0.2rem;
+  //margin-left: 0.5rem;
+  //position: absolute;
+  //left: -5px;
 }
 
-.labelled-input > label {
-    display: block;
-    max-width: 100%;
-    margin-bottom: 0;
-    font-weight: 500;
-    font-size: 0.8rem;
-    margin-top: 1rem;
+.labelled-input>label {
+  display: block;
+  max-width: 100%;
+  margin-bottom: 0;
+  font-weight: 500;
+  font-size: 0.8rem;
+  margin-top: 1rem;
 }
 </style>
 
 <style>
-.label-message > .p-message-content {
-    padding: 0 0.5rem;
-    font-size: 0.6rem;
-    background: var(--p-panel-background);
-    border: none;
+.label-message>.p-message-content {
+  padding: 0 0.5rem;
+  font-size: 0.6rem;
+  background: var(--p-panel-background);
+  border: none;
 }
 
 .p-message.label-message {
-    outline-style: none;
-    box-shadow: none;
+  outline-style: none;
+  box-shadow: none;
 }
 
 .label-message .p-message-text {
-    font-size: 0.6rem !important;
+  font-size: 0.6rem !important;
 }
 
 .p-message-secondary {
-    background: unset;
+  background: unset;
 }
 </style>


### PR DESCRIPTION
This PR updates the LabelledInput.vue and LabelledCheckboxInput.vue components based on the ones bcrhp repository. This fixes the CSS issues that were present, as well as keeps the commonly used component files where they should be.

NOTE: this must be merged together alongside with the same branch name, 'yg/feat/1253-move-reusable-labelledinput-and-labelledcheckboxinput-into-common', but into the bcrhp repository, as this contains CSS fixes to the original LabelledInput.vue and LabelledCheckboxInput.vue components.
