### PR TITLE
Add Concept Radio Button component & Fix Select Concept component

### DIFF
--- a/bcgov_arches_common/src/bcgov_arches_common/components/ConceptSelect/ConceptRadioButtons.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/components/ConceptSelect/ConceptRadioButtons.vue
@@ -4,7 +4,6 @@ import { getConceptsForNode } from '@/bcgov_arches_common/api.ts';
 import RadioButton from 'primevue/radiobutton';
 import RadioButtonGroup from 'primevue/radiobuttongroup';
 
-
 const model = defineModel();
 const props = defineProps({
     graphSlug: { type: String, required: true },
@@ -18,10 +17,6 @@ const emit = defineEmits(['valueUpdated']);
 
 const options = ref([]);
 
-onMounted(() => {
-    getConceptsForNode(props.graphSlug, props.nodeAlias, options);
-});
-
 const valueUpdated = function (event: Event) {
     emit('valueUpdated', event.target.value, event.target);
 };
@@ -29,14 +24,17 @@ const valueUpdated = function (event: Event) {
 const flexDirection = computed(() => {
     return props.groupDirection === 'column' ? 'flex-col' : 'flex-row gap-2';
 });
+
+onMounted(() => {
+    getConceptsForNode(props.graphSlug, props.nodeAlias, options);
+});
 </script>
 
 <template>
     <RadioButtonGroup
         v-model="model"
         name="id"
-        class="flex flex-wrap"
-        :class="flexDirection"
+        :class="['flex flex-wrap', flexDirection]"
     >
         <div
             v-for="option in options"

--- a/bcgov_arches_common/src/bcgov_arches_common/components/ConceptSelect/ConceptRadioButtons.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/components/ConceptSelect/ConceptRadioButtons.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { onMounted, ref, computed } from 'vue';
+import { getConceptsForNode } from '@/bcgov_arches_common/api.ts';
+import RadioButton from 'primevue/radiobutton';
+import RadioButtonGroup from 'primevue/radiobuttongroup';
+
+
+const model = defineModel();
+const props = defineProps({
+    graphSlug: { type: String, required: true },
+    nodeAlias: { type: String, required: true },
+    id: { type: String, required: true },
+    placeholder: { type: String, default: 'Select an option' },
+    groupDirection: { type: String, default: 'column' },
+});
+
+const emit = defineEmits(['valueUpdated']);
+
+const options = ref([]);
+
+onMounted(() => {
+    getConceptsForNode(props.graphSlug, props.nodeAlias, options);
+});
+
+const valueUpdated = function (event: Event) {
+    emit('valueUpdated', event.target.value, event.target);
+};
+
+const flexDirection = computed(() => {
+    return props.groupDirection === 'column' ? 'flex-col' : 'flex-row gap-2';
+});
+</script>
+
+<template>
+    <RadioButtonGroup
+        v-model="model"
+        name="id"
+        class="flex flex-wrap"
+        :class="flexDirection"
+    >
+        <div
+            v-for="option in options"
+            :key="option.id"
+            class="flex items-center gap-2"
+        >
+            <RadioButton
+                v-model="model"
+                :input-id="option.id"
+                name="dynamic"
+                :value="option.id"
+                variant="filled"
+                size="small"
+                @change="valueUpdated"
+            />
+            <label :for="option.id">{{ option.text }}</label>
+        </div>
+    </RadioButtonGroup>
+</template>
+
+<style scoped></style>
+
+<style></style>

--- a/bcgov_arches_common/src/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue
+++ b/bcgov_arches_common/src/bcgov_arches_common/components/ConceptSelect/ConceptSelect.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { onMounted, ref, type PropType, type Ref, useTemplateRef } from 'vue';
+import { onMounted, ref, useTemplateRef } from 'vue';
 import { getConceptsForNode } from '@/bcgov_arches_common/api.ts';
 import Select from 'primevue/select';
+import { type SelectChangeEvent } from 'primevue/select';
 
+const model = defineModel();
 const props = defineProps({
     graphSlug: { type: String, required: true },
     nodeAlias: { type: String, required: true },
-    modelValue: { type: Object as PropType<Ref>, required: true },
     id: { type: String, required: true },
     placeholder: { type: String, default: 'Select an option' },
 });
@@ -17,20 +18,26 @@ const options = ref([]);
 
 const conceptSelectField = useTemplateRef('conceptSelectField');
 
+// const getLabelForOption = function (optionId: string) {
+//     return options.value.find((option) => option.id === optionId)?.text;
+// };
+
 onMounted(() => {
     getConceptsForNode(props.graphSlug, props.nodeAlias, options);
 });
 
-const valueUpdated = function (newValue: Object) {
-    emit('valueUpdated', newValue, conceptSelectField.value);
+const valueUpdated = function (event: SelectChangeEvent) {
+    emit('valueUpdated', event.value, conceptSelectField);
 };
+
+// defineExpose(getLabelForOption);
 </script>
 
 <template>
     <Select
-        :id="props.id"
-        v-model="props.modelValue"
         ref="conceptSelectField"
+        v-model="model"
+        :input-id="props.id"
         option-label="text"
         option-value="id"
         :placeholder="props.placeholder"
@@ -39,8 +46,8 @@ const valueUpdated = function (newValue: Object) {
         aria-required="true"
         fluid
         class="w-full md:w-14rem"
-        @update:model-value="valueUpdated"
-        @value-change="valueUpdated"
+        size="small"
+        @change="valueUpdated"
     />
 </template>
 


### PR DESCRIPTION
This PR:
1. adds the Radio Button concept widget and applies it to Step 9 of the workflow
2. updates the pattern used by ConceptSelect to use v-model reactive prop

Still to do:
Allow users to translate the Concept UUIDs to Labels for lookup.